### PR TITLE
re-use errorsLimit from queryValidator

### DIFF
--- a/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
+++ b/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
@@ -16,6 +16,9 @@ trait QueryValidator {
       schema: Schema[_, _],
       queryAst: ast.Document,
       errorsLimit: Option[Int]): Vector[Violation]
+
+  def errorsLimit: Option[Int]
+  def withErrorsLimit(limit: Int): QueryValidator
 }
 
 object QueryValidator {
@@ -62,6 +65,9 @@ object QueryValidator {
         schema: Schema[_, _],
         queryAst: ast.Document,
         errorsLimit: Option[Int]): Vector[Violation] = Vector.empty
+
+    override def errorsLimit: Option[Int] = None
+    override def withErrorsLimit(limit: Int): QueryValidator = this
   }
 
   val default: RuleBasedQueryValidator = ruleBased(allRules, errorsLimit = Some(10))
@@ -69,8 +75,12 @@ object QueryValidator {
 
 class RuleBasedQueryValidator(
     rules: List[ValidationRule],
-    errorsLimit: Option[Int]
+    val errorsLimit: Option[Int]
 ) extends QueryValidator {
+
+  def withErrorsLimit(limit: Int): RuleBasedQueryValidator =
+    new RuleBasedQueryValidator(rules, Some(limit))
+
   def validateQuery(schema: Schema[_, _], queryAst: ast.Document): Vector[Violation] =
     validateQuery(schema, queryAst, errorsLimit)
 

--- a/modules/core/src/test/scala/sangria/util/GraphQlSupport.scala
+++ b/modules/core/src/test/scala/sangria/util/GraphQlSupport.scala
@@ -30,6 +30,10 @@ object SimpleGraphQlSupport extends FutureResultSupport with Matchers {
       HandledException(e.getMessage)
     }
 
+    val queryValidator = if (validateQuery) QueryValidator.default else QueryValidator.empty
+    val queryValidatorWithErrorsLimits =
+      errorsLimit.fold(queryValidator)(queryValidator.withErrorsLimit)
+
     Executor
       .execute(
         schema.asInstanceOf[Schema[Any, T]],
@@ -38,9 +42,8 @@ object SimpleGraphQlSupport extends FutureResultSupport with Matchers {
         data,
         variables = args,
         exceptionHandler = exceptionHandler,
-        queryValidator = if (validateQuery) QueryValidator.default else QueryValidator.empty,
-        deferredResolver = resolver,
-        errorsLimit = errorsLimit
+        queryValidator = queryValidatorWithErrorsLimits,
+        deferredResolver = resolver
       )
       .awaitAndRecoverQueryAnalysisScala
   }


### PR DESCRIPTION
What do you think of using the existing `errorsLimit` from the `queryValidator`?